### PR TITLE
[ci skip] adding user @quantumjot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/napari
+* @quantumjot @conda-forge/napari

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,4 +43,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - quantumjot
     - conda-forge/napari


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @quantumjot as instructed in #1.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #1